### PR TITLE
Add support for softlayer, rackspace and openstack, and swift backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Barkup is a library for backing things up. It provides tools for writing bare-bo
 
 **Exporters:** `MySQL` `Postgres` `RethinkDB`
 
-**Storers:** `S3`
+**Storers:** `S3` `SoftLayers object storage` `Rackspace cloud files` `Swift object storage` `Openstack object storage`
 
 ## Quick Example (mysql to s3)
 
@@ -217,3 +217,20 @@ err := someExportResult.To("data/", s3)
 * ap-northeast-1
 * sa-east-1
 
+
+
+### Softlayer, Openstack, Swift, Rackspace
+
+
+**Usage**
+
+```go
+o := &barkup.ObjectStorage{
+		APIKey:    "xx",
+		Username:  "xx",
+		AuthURL:   "xx", // tested with V1 auth urls
+		Container: "xx",
+	}
+
+	err := result.To(result.Filename(), o)
+```

--- a/object_storage.go
+++ b/object_storage.go
@@ -1,0 +1,51 @@
+package barkup
+
+import (
+	"bufio"
+	"os"
+
+	"github.com/ncw/swift"
+)
+
+// ObjectStorage is a `Storer` interface that puts an ExportResult to the specified container/bucket. This can be used to backup to rackspace/swift/openstack and softlayers object storage solutions
+type ObjectStorage struct {
+	APIKey      string
+	Username    string
+	Container   string
+	AuthURL     string
+	Hash        string
+	ContentType string
+	CheckHash   bool
+	Headers     swift.Headers
+}
+
+// Store stores the result in the given directory path for the container specified in the caller
+func (o *ObjectStorage) Store(result *ExportResult, directory string) *Error {
+	if result.Error != nil {
+		return result.Error
+	}
+
+	file, err := os.Open(result.Path)
+	if err != nil {
+		return makeErr(err, "")
+	}
+	defer file.Close()
+
+	buffy := bufio.NewReader(file)
+
+	// Create a v1 auth connection
+	c := swift.Connection{
+		UserName: o.Username,
+		ApiKey:   o.APIKey,
+		AuthUrl:  o.AuthURL,
+	}
+
+	// Authenticate
+	err = c.Authenticate()
+	if err != nil {
+		makeErr(err, "")
+	}
+
+	_, err = c.ObjectPut(o.Container, directory, buffy, o.CheckHash, o.Hash, o.ContentType, o.Headers)
+	return makeErr(err, "")
+}

--- a/object_storage_test.go
+++ b/object_storage_test.go
@@ -1,0 +1,54 @@
+package barkup
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ncw/swift/swifttest"
+)
+
+func Test_Object_Storeage_Store_Success(t *testing.T) {
+	stest, err := swifttest.NewSwiftServer("0.0.0.0")
+
+	s := &ObjectStorage{
+		Username:  swifttest.TEST_ACCOUNT,
+		APIKey:    swifttest.TEST_ACCOUNT,
+		Container: "test",
+		AuthURL:   stest.AuthURL,
+	}
+
+	_, err = os.Create("test.txt")
+	err = s.Store(&ExportResult{"test.txt", "text/plain", nil}, "")
+	expect(t, err, (*Error)(nil))
+}
+
+func Test_Object_Storage_Store_Fail(t *testing.T) {
+	stest, err := swifttest.NewSwiftServer("0.0.0.0")
+	stest.Close()
+
+	s := &ObjectStorage{
+		Username:  swifttest.TEST_ACCOUNT,
+		APIKey:    swifttest.TEST_ACCOUNT,
+		Container: "test",
+		AuthURL:   stest.AuthURL,
+	}
+
+	_, _ = os.Create("test.txt")
+	err = s.Store(&ExportResult{"test.txt", "text/plain", nil}, "")
+	refute(t, err, (*Error)(nil))
+}
+
+func Test_Object_Storage_Store_ExportError(t *testing.T) {
+	stest, err := swifttest.NewSwiftServer("0.0.0.0")
+
+	s := &ObjectStorage{
+		Username:  swifttest.TEST_ACCOUNT,
+		APIKey:    swifttest.TEST_ACCOUNT,
+		Container: "test",
+		AuthURL:   stest.AuthURL,
+	}
+
+	_, _ = os.Create("test/test.txt")
+	err = s.Store(&ExportResult{"", "text/plain", &Error{}}, "test/")
+	refute(t, err, nil)
+}


### PR DESCRIPTION
Tested it out with softlayers backups, the external dependency being used is generic enough to support the others so they should work fine

@keighl let me know what you think
