### PR TITLE
Log CombinedOutput instead of just Output

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -38,14 +38,14 @@ func (x MySQL) Export() *ExportResult {
 	dumpPath := fmt.Sprintf(`bu_%v_%v.sql`, x.DB, time.Now().Unix())
 
 	options := append(x.dumpOptions(), fmt.Sprintf(`-r%v`, dumpPath))
-	out, err := exec.Command(MysqlDumpCmd, options...).Output()
+	out, err := exec.Command(MysqlDumpCmd, options...).CombinedOutput()
 	if err != nil {
 		result.Error = makeErr(err, string(out))
 		return result
 	}
 
 	result.Path = dumpPath + ".tar.gz"
-	_, err = exec.Command(TarCmd, "-czf", result.Path, dumpPath).Output()
+	_, err = exec.Command(TarCmd, "-czf", result.Path, dumpPath).CombinedOutput()
 	if err != nil {
 		result.Error = makeErr(err, string(out))
 		return result

--- a/postgres.go
+++ b/postgres.go
@@ -31,7 +31,7 @@ func (x Postgres) Export() *ExportResult {
 	result := &ExportResult{MIME: "application/x-tar"}
 	result.Path = fmt.Sprintf(`bu_%v_%v.sql.tar.gz`, x.DB, time.Now().Unix())
 	options := append(x.dumpOptions(), "-Fc", fmt.Sprintf(`-f%v`, result.Path))
-	out, err := exec.Command(PGDumpCmd, options...).Output()
+	out, err := exec.Command(PGDumpCmd, options...).CombinedOutput()
 	if err != nil {
 		result.Error = makeErr(err, string(out))
 	}

--- a/rethinkdb.go
+++ b/rethinkdb.go
@@ -32,7 +32,7 @@ func (x RethinkDB) Export() *ExportResult {
 	result := &ExportResult{MIME: "application/x-tar"}
 	result.Path = fmt.Sprintf(`bu_%v_%v.tar.gz`, x.Name, time.Now().Unix())
 	options := append(x.dumpOptions(), fmt.Sprintf(`-f%v`, result.Path))
-	out, err := exec.Command(RethinkCmd, options...).Output()
+	out, err := exec.Command(RethinkCmd, options...).CombinedOutput()
 	if err != nil {
 		result.Error = makeErr(err, string(out))
 	}


### PR DESCRIPTION
`Output()` only shows the messages written to `stdout` but not `stderr`.
Switching to `CombinedOutput()` would log both `stdout` and `stderr` to
`result.Error.CmdOutput`.