### PR TITLE
[WIP] Make dbname optional

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -1,10 +1,14 @@
 package barkup
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"os/exec"
 	"time"
+
+	// import mysql driver
+	_ "github.com/go-sql-driver/mysql"
 )
 
 var (
@@ -35,32 +39,69 @@ type MySQL struct {
 func (x MySQL) Export() *ExportResult {
 	result := &ExportResult{MIME: "application/x-tar"}
 
-	dumpPath := fmt.Sprintf(`bu_%v_%v.sql`, x.DB, time.Now().Unix())
+	dumpPath := fmt.Sprintf(`bu_%v`, time.Now().Unix())
+	var (
+		dbs []string
+		err error
+	)
+	if x.DB != "" {
+		dbs = []string{x.DB}
+	} else {
+		dbs, err = x.getDBNames()
+		if err != nil {
+			result.Error = makeErr(err, "MySQL connection error")
+			return result
+		}
+	}
 
-	options := append(x.dumpOptions(), fmt.Sprintf(`-r%v`, dumpPath))
-	out, err := exec.Command(MysqlDumpCmd, options...).Output()
-	if err != nil {
-		result.Error = makeErr(err, string(out))
-		return result
+	os.Mkdir(dumpPath, 0770)
+	for _, db := range dbs {
+		dumpFile := fmt.Sprintf(`bu_%v_%v.sql`, db, time.Now().Unix())
+		options := append(x.dumpOptions(db), fmt.Sprintf(`-r%v/%v`, dumpPath, dumpFile))
+		out, err := exec.Command(MysqlDumpCmd, options...).Output()
+		if err != nil {
+			result.Error = makeErr(err, string(out))
+			return result
+		}
 	}
 
 	result.Path = dumpPath + ".tar.gz"
-	_, err = exec.Command(TarCmd, "-czf", result.Path, dumpPath).Output()
+	out, err := exec.Command(TarCmd, "-czf", result.Path, dumpPath).Output()
 	if err != nil {
 		result.Error = makeErr(err, string(out))
 		return result
 	}
-	os.Remove(dumpPath)
+	os.RemoveAll(dumpPath)
 
 	return result
 }
 
-func (x MySQL) dumpOptions() []string {
+func (x MySQL) getDBNames() ([]string, error) {
+	db, err := sql.Open("mysql", fmt.Sprintf("%v:%v@tcp(%v:%v)/", x.User, x.Password, x.Host, x.Port))
+	if err != nil {
+		return []string{}, err
+	}
+	defer db.Close()
+	rows, err := db.Query("SELECT SCHEMA_NAME FROM `information_schema`.`SCHEMATA` WHERE SCHEMA_NAME NOT REGEXP 'information_schema|performance_schema|sys'")
+	if err != nil {
+		return []string{}, err
+	}
+	defer rows.Close()
+	var dbs []string
+	for rows.Next() {
+		var name string
+		rows.Scan(&name)
+		dbs = append(dbs, name)
+	}
+	return dbs, nil
+}
+
+func (x MySQL) dumpOptions(db string) []string {
 	options := x.Options
 	options = append(options, fmt.Sprintf(`-h%v`, x.Host))
 	options = append(options, fmt.Sprintf(`-P%v`, x.Port))
 	options = append(options, fmt.Sprintf(`-u%v`, x.User))
 	options = append(options, fmt.Sprintf(`-p%v`, x.Password))
-	options = append(options, x.DB)
+	options = append(options, db)
 	return options
 }


### PR DESCRIPTION
Hello i decided to write an improved version of the mysql exporter. 

What: Made the mysql exporter able to backup all databases into separate sql files.
Why: When I backup mysql, I find it very convenient to have one file per database. Current exporter only supported one file through the `--all-databases` flag.
How: Connect to the database and retrieve the database names. Loop through them calling mysqldump for each of them.

This is WIP, I didn't write tests and I am new to go. I would like to hear your thoughts. :)